### PR TITLE
Adds `modifyBlocks` option to make structure read-only

### DIFF
--- a/src/block.js
+++ b/src/block.js
@@ -341,17 +341,19 @@ Object.assign(Block.prototype, SimpleBlock.fn, require('./block-validations'), {
    //Init functions for adding functionality
   _initUIComponents: function() {
 
-    this.addDeleteControls();
+    if (config.defaults.modifyBlocks) {
+      this.addDeleteControls();
 
-    this.positioner = new BlockPositioner(this.el, this.mediator);
+      this.positioner = new BlockPositioner(this.el, this.mediator);
 
-    this._withUIComponent(this.positioner, '.st-block-ui-btn__reorder',
-                          this.onPositionerClick);
+      this._withUIComponent(this.positioner, '.st-block-ui-btn__reorder',
+                            this.onPositionerClick);
 
-    this._withUIComponent(new BlockReorder(this.el, this.mediator));
+      this._withUIComponent(new BlockReorder(this.el, this.mediator));
 
-    this._withUIComponent(new BlockDeletion(), '.st-block-ui-btn__delete',
-                          this.onDeleteClick);
+      this._withUIComponent(new BlockDeletion(), '.st-block-ui-btn__delete',
+                            this.onDeleteClick);
+    }
 
     this.onFocus();
     this.onBlur();

--- a/src/blocks/scribe-plugins/scribe-text-block-plugin.js
+++ b/src/blocks/scribe-plugins/scribe-text-block-plugin.js
@@ -6,6 +6,8 @@ var {
   selectToEnd
 } = require('./shared.js');
 
+var config = require('./../../config');
+
 var ScribeTextBlockPlugin = function(block) {
   return function(scribe) {
 
@@ -53,7 +55,7 @@ var ScribeTextBlockPlugin = function(block) {
 
     scribe.el.addEventListener('keydown', function(ev) {
 
-      if (block.supressKeyListeners) {
+      if (block.supressKeyListeners || !config.defaults.modifyBlocks) {
         return;
       }
 
@@ -90,7 +92,7 @@ var ScribeTextBlockPlugin = function(block) {
 
     scribe.el.addEventListener('keyup', function(ev) {
 
-      if (block.supressKeyListeners) {
+      if (block.supressKeyListeners || !config.defaults.modifyBlocks) {
         return;
       }
 

--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,7 @@ var upload_options = {
 };
 
 module.exports = {
-  debug: false,
+  debug: true,
   scribeDebug: false,
   skipValidation: false,
   version: "0.4.0",
@@ -32,6 +32,9 @@ module.exports = {
   instances: [],
 
   defaults: {
+    // If set to false will not allow users to add/remove or move blocks
+    modifyBlocks: true,
+
     defaultType: false,
     spinner: {
       className: 'st-spinner',

--- a/src/templates/block-addition-top.js
+++ b/src/templates/block-addition-top.js
@@ -3,6 +3,10 @@
 var config = require('../config');
 
 module.exports = () => {
+  if (!config.defaults.modifyBlocks) {
+    return '';
+  }
+
   return `
     <div class="st-block-addition-top">
       <div class="st-block-addition-top__button" type="button"></div>

--- a/src/templates/block-addition.js
+++ b/src/templates/block-addition.js
@@ -3,6 +3,10 @@
 var config = require('../config');
 
 module.exports = () => {
+  if (!config.defaults.modifyBlocks) {
+    return '';
+  }
+
   return `
     <button class="st-block-addition" type="button">
       <span class="st-block-addition__button">


### PR DESCRIPTION
Setting the option to false won't allow users to add/remove or re-order
blocks.

Hides the UI interfaces as well.